### PR TITLE
adds routing to index.html for all front end routes

### DIFF
--- a/react-backend/app.js
+++ b/react-backend/app.js
@@ -17,6 +17,7 @@ const registerCB = require('./routes/cbauthentication/registerCB');
 const checkCBlogin = require('./routes/cbauthentication/checkCBlogin');
 const checkPassword = require('./routes/cbauthentication/checkPassword');
 const CBPasswordResetInstigator = require('./routes/cbauthentication/CBPasswordResetInstigator');
+const frontEndRoutes = require('./frontEndRoutes');
 
 const app = express();
 
@@ -25,10 +26,14 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
-// app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.static(path.join(__dirname, 'client/build')));
 
-app.use('/', index);
+frontEndRoutes.forEach(route =>
+  app.use(
+    route,
+    express.static(path.join(__dirname, 'client/build/index.html'))
+  )
+);
 app.use('/qrgenerator', qrgenerator);
 app.use('/getUsername', getUsername);
 app.use('/all-users', getAllUsers);

--- a/react-backend/frontEndRoutes.js
+++ b/react-backend/frontEndRoutes.js
@@ -1,0 +1,12 @@
+module.exports = [
+  '/signupcb',
+  '/newPassword',
+  '/pswdresetcb',
+  '/logincb',
+  '/visitor',
+  '/visitor/signup',
+  '/visitor/login',
+  '/visitor/qrerror',
+  '/visitor/end',
+  '/admin'
+];


### PR DESCRIPTION
This PR adds routing in the express server to `client/build/index.html` for all front end routes (i.e. the ones handled by react-router).

This has been done by hand writing all of the front end routes in a `frontEndRoutes.js` file, and then looping through then in the express `app.js` file, and setting them to serve the static index page on each of them. 

This means that whenever we add a new front end route handled by react-router in `client/App.js`, we have to add it to `frontEndRoutes.js` as well. It would be good to do this automatically in future, but for now I can't see how.

Please both of you (@RogeredBacon and @azayneeva) review the PR, and the second one to approve can merge and deploy. 

fix #108 