### PR TITLE
🐛 fix weird activities page bug

### DIFF
--- a/client/src/cb-admin/components/Checkbox.js
+++ b/client/src/cb-admin/components/Checkbox.js
@@ -9,7 +9,6 @@ const Control = styled.div`
   & input {
     z-index: -1;
     opacity: 0;
-    position: absolute;
   }
 
   & input + label:before {
@@ -20,7 +19,6 @@ const Control = styled.div`
     border-radius: 50%;
     border: 0.1em solid ${colors.light};
     background: transparent;
-    position: relative;
   }
 
   & input:checked + label:before {

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -2,8 +2,11 @@
 
 ## Contents
 
-[Database Schema Woes](#database-schema-woes)
+1. [Database Time Zones](#database-time-zones)
+2. [Flexbox and Absolute Positioned Children](#flexbox-and-absolute-positioned-children)
 
-## Database Schema Woes
-
+## Database Time Zones
 All `date` data types in schema are set as `TIMESTAMP WITH TIME ZONE`, with entries being added as UTC in the following format `2017-05-15 12:24:56+00`. Without `TIME ZONE` added node servers will convert `date` data into js time objects in local time.
+
+## Flexbox and Absolute Positioned Children
+[As spelled out by w3](https://www.w3.org/TR/css-flexbox-1/#abspos-items), absolute positioned children of flex container parents will be positioned as though they are the sole flex item in the container. This can (and has) cause(d) some weirdness, so it's best to not use absolute positioning in children of flex-containers.


### PR DESCRIPTION
Fixes #353

Turns out to be a styling bug. I don't understand the mechanics of it, but I can no longer reproduce the bug.

It was probably that the absolute positioning on the input elements was somehow messing with the flexbox layouts. I removed the absolute positioning, since it looked to be having no effect anyway (except for causing this bug).

Also seems to be unique to Chrome, as was unable to reproduce on Firefox.


#### Checklist
##### Fixing Bugs
* [x] Have I documented any necessary developer notes/gotchas/lessons learnt from this bug fix?