### PR TITLE
🐛 fix hard-reload issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ app.use(compression());
 app.use(express.static(path.join(__dirname, 'build')));
 
 // All unmatched GET requests should serve "index.html"
-app.get('/*', express.static(path.join(__dirname, 'build', 'index.html')));
+app.use((_, res) => res.sendFile(path.resolve(__dirname, 'build', 'index.html')));
 
 // Start server
 app.listen(process.env.PORT || 3000, () => console.log(`Listening on ${process.env.PORT || 3000}`));


### PR DESCRIPTION
Prevents requests from falling through to the default express 404 page, serving the `index.html` back when the route is not explicitly recognised.